### PR TITLE
Add posibility to deploy ceph mon

### DIFF
--- a/ceph/defaults.yaml
+++ b/ceph/defaults.yaml
@@ -8,3 +8,5 @@ ceph:
   config:
     global:
       authentication_type: 'cephx'
+  mon_hosts: []
+

--- a/ceph/init.sls
+++ b/ceph/init.sls
@@ -16,3 +16,10 @@ ceph_config_file:
     - sections:
         global:
           {{ settings.config.global }}
+
+ceph_config_mon_host:
+  ini.options_present:
+    - name: /etc/ceph/ceph.conf
+    - sections:
+        global:
+          mon_host: {{ settings.mon_hosts|join(', ') }}

--- a/ceph/mon.sls
+++ b/ceph/mon.sls
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+{% from "ceph/map.jinja" import settings with context -%}
+
+{% set mon_name = 'mymon' %}
+{% set mon_dir = salt['cmd.run']('ceph-mon  --id ' ~ mon_name ~ ' --show-config-value mon_data') %}
+
+mkdir_dir_for_{{ mon_name }}:
+  file.directory:
+    - name: {{ mon_dir }}
+    - user: ceph
+    - group: ceph
+
+add_mon_{{ mon_name }}:
+  cmd.run:
+    - name: "ceph-mon --setuser ceph --setgroup ceph --mkfs --id {{ mon_name }} --keyring /dev/null"
+    - unless: 'test -d {{ mon_dir }}/store.db'
+
+start_mon_service_for_{{ mon_name }}:
+  service.running:
+     - name: ceph-mon@{{ mon_name }}


### PR DESCRIPTION
Using below pillars you can easily deploy ceph mon

```
ceph:
  config:
    global:
      fsid: 0d32f09d-35be-40a0-a76e-65f899cbbaba
      authentication_type: 'none'
  mon_hosts:
    - 10.0.2.15
```

Commands:

```
salt your-host state.sls ceph
salt your-host state.sls ceph.mon
```
