### PR TITLE
Fix ceph.repo state for Beryllium

### DIFF
--- a/ceph/osfamilymap.yaml
+++ b/ceph/osfamilymap.yaml
@@ -13,7 +13,7 @@ RedHat:
     humanname: Ceph {{ repo.release }} $releasever - $basearch
     gpgcheck: 1
     gpgkey: '{{ repo.official }}/keys/release.asc'
-    baseurl: '{{ repo.official }}/rpm-{{ repo.release }}/el{{ grains.osmajorrelease }}/$basearch'
+    baseurl: '{{ repo.official }}/rpm-{{ repo.release }}/el{{ grains.osrelease_info[0] }}/$basearch'
 
 Suse:
   pkg_repo:

--- a/pillar.example
+++ b/pillar.example
@@ -23,3 +23,6 @@ ceph:
       - /dev/sdj:/dev/sdb1 # data-path:journal-path
     removed:
       - /dev/sde
+
+  packages:
+    - apt-transport-https


### PR DESCRIPTION
This PR fixes the failed `ceph.repo` state on salt-call 2015.8.8 (Beryllium).

```
    Rendering SLS 'base:ceph.repo' failed: Jinja variable 'dict object' has no attribute 'osmajorrelease'
/var/cache/salt/minion/files/base/ceph/osfamilymap.yaml(23):
```

Also update `pillar.example` to document required package on Ubuntu.