### PR TITLE
Fix for 2019.2.0 release

### DIFF
--- a/ceph/init.sls
+++ b/ceph/init.sls
@@ -8,7 +8,7 @@ include:
 
 install_ceph_pkgs:
   pkg.installed:
-    - pkgs: {{ ceph.packages }}
+    - pkgs: {{ ceph.packages|tojson }}
 
 create_ceph_config_file:
   file.touch:

--- a/ceph/init.sls
+++ b/ceph/init.sls
@@ -8,7 +8,7 @@ include:
 
 install_ceph_pkgs:
   pkg.installed:
-    - pkgs: {{ ceph.packages|tojson }}
+    - pkgs: {{ ceph.packages | json }}
 
 create_ceph_config_file:
   file.touch:


### PR DESCRIPTION
Without this fix you'll get errors like "package u'ceph' not found" due to https://docs.saltstack.com/en/develop/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer