### PR TITLE
fix(archlinux): workaround grain-rendering errors

### DIFF
--- a/ceph/osfamilymap.yaml
+++ b/ceph/osfamilymap.yaml
@@ -13,7 +13,7 @@ RedHat:
     humanname: Ceph {{ repo.release }} $releasever - $basearch
     gpgcheck: 1
     gpgkey: '{{ repo.official }}/keys/release.asc'
-    baseurl: '{{ repo.official }}/rpm-{{ repo.release }}/el{{ grains.osrelease_info[0] }}/$basearch'
+    baseurl: {{ repo.official }}/rpm-{{ repo.release }}/el{{ '' if 'osrelease_info' not in grains else grains.osrelease_info[0] }}/$basearch
 
 Suse:
   oscode: openSUSE_Tumbleweed

--- a/ceph/repo/init.sls
+++ b/ceph/repo/init.sls
@@ -28,6 +28,6 @@ ceph-repo:
 ceph-repo:
   test.show_notification:
     - text: |
-        Ceph does not provide package repository for {{ grains['osfinger'] }}
+        Ceph does not provide package repository for {{ grains.os_family }}
 
 {%- endif %}


### PR DESCRIPTION
This PR fixes `ceph.repo` state rendering errors on Archlinux.

Archlinux has smaller subset of "os" grains.
```
    os:
        Arch
    os_family:
        Arch
    osarch:
        x86_64
    oscodename:
        Arch Linux
    osfullname:
        Arch Linux
```